### PR TITLE
add nix file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist-newstyle/
 cabal.project.local*
 .ghc.environment.*
+*.swp

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ config ? { allowBroken = true; }, ... }:
+{ envFor ? null, config ? { allowBroken = true; }, ... }:
 let
   # fetch pinned version of nixpkgs
   nixpkgs = import (
@@ -67,17 +67,16 @@ let
     pkg.vrdt
   ];
 in
-if nixpkgs.lib.inNixShell
-then nixpkgs.stdenv.mkDerivation {
-  name = "stub";
-  buildInputs = [
-    (haskellPackages.ghcWithPackages packages)
-    haskellPackages.hpack
-    nixpkgs.cabal-install
-    nixpkgs.ghcid
-  ];
-}
-else nixpkgs.buildEnv {
+if envFor == null
+then nixpkgs.buildEnv {
   name = "vrdt-project";
   paths = packages haskellPackages;
 }
+else haskellPackages."${envFor}".env.overrideAttrs (
+  old: {
+    nativeBuildInputs = old.nativeBuildInputs ++ [
+      nixpkgs.cabal-install
+      nixpkgs.ghcid
+    ];
+  }
+)

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,48 @@
+{ config ? { allowBroken = true; }, ... }:
+let
+  # fetch pinned version of nixpkgs
+  nixpkgs = import (
+    builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs-channels/archive/1a92d0abfcdbafc5c6e2fdc24abf2cc5e011ad5a.tar.gz";
+      sha256 = "1f9ypp9q7r5p1bzm119yfg202fbm83csmlzwv33p1kf76m2p7mwd";
+    }
+  ) { inherit config; };
+  # override haskell compiler version, add and override dependencies in nixpkgs
+  haskellPackages = nixpkgs.haskellPackages.override (
+    old: {
+      overrides = self: super: with nixpkgs.haskell.lib; {
+        # add dependencies not on hackage
+        kyowon-client = self.callCabal2nix "kyowon-client" ./kyowon-client {};
+        kyowon-core = self.callCabal2nix "kyowon-core" ./kyowon-core {};
+        kyowon-reflex =
+          dontCheck # the tests are missing language-extensions
+            (
+              dontHaddock # a commented application operator is a haddock parse error
+                (
+                  self.callCabal2nix "kyowon-reflex" ./kyowon-reflex {}
+                )
+            );
+        vrdt =
+          dontCheck # Spec.hs isn't checked into the repo
+            (
+              dontHaddock # commented guard case is a haddock parse error 
+                (
+                  self.callCabal2nix "vrdt" ./vrdt {}
+                )
+            );
+        # fix dependency versions
+        patch = self.callHackage "patch" "0.0.2.0" {}; # version used in stack.yaml
+        dependent-map = self.callHackage "dependent-map" "0.3" {}; # version used in stack.yaml
+        dependent-sum = self.callHackage "dependent-sum" "0.6.2.0" {}; # version used in stack.yaml
+        witherable = self.callHackage "witherable" "0.3.1" {}; # version used in stack.yaml
+        monoidal-containers = self.callHackage "monoidal-containers" "0.6.0.1" {}; # version used in stack.yaml
+        bimap = self.callHackage "bimap" "0.3.3" {}; # version used in stack.yaml
+      };
+    }
+  );
+  # function to bring devtools in to a package environment
+  devtools = old: { nativeBuildInputs = old.nativeBuildInputs ++ [ nixpkgs.cabal-install nixpkgs.ghcid ]; }; # ghc and hpack are automatically included
+  # use overridden-haskellPackages to call source
+  drv = haskellPackages.callCabal2nix "collaborate" ./examples/collaborate {};
+in
+if nixpkgs.lib.inNixShell then (drv.envFunc { hoogle = true; }).overrideAttrs devtools else drv

--- a/default.nix
+++ b/default.nix
@@ -7,20 +7,22 @@ let
       sha256 = "1f9ypp9q7r5p1bzm119yfg202fbm83csmlzwv33p1kf76m2p7mwd";
     }
   ) { inherit config; };
+  # function to respect gitignore files
+  ign = src: nixpkgs.nix-gitignore.gitignoreSource [] src;
   # override haskell compiler version, add and override dependencies in nixpkgs
   haskellPackages = nixpkgs.haskellPackages.override (
     old: {
       overrides = self: super: with nixpkgs.haskell.lib; {
 
         # add dependencies not on hackage
-        kyowon-client = self.callCabal2nix "kyowon-client" ./kyowon-client {};
-        kyowon-core = self.callCabal2nix "kyowon-core" ./kyowon-core {};
+        kyowon-client = self.callCabal2nix "kyowon-client" (ign ./kyowon-client) {};
+        kyowon-core = self.callCabal2nix "kyowon-core" (ign ./kyowon-core) {};
         kyowon-reflex =
           # the tests are missing language-extensions
           dontCheck (
             # a commented application operator is a haddock parse error
             dontHaddock (
-              self.callCabal2nix "kyowon-reflex" ./kyowon-reflex {}
+              self.callCabal2nix "kyowon-reflex" (ign ./kyowon-reflex) {}
             )
           );
         vrdt =
@@ -33,7 +35,7 @@ let
           );
 
         # add executables also
-        kyowon-server = haskellPackages.callCabal2nix "kyowon-server" ./kyowon-server {};
+        kyowon-server = haskellPackages.callCabal2nix "kyowon-server" (ign ./kyowon-server) {};
         example-collaborate = haskellPackages.callCabal2nix "collaborate" ./examples/collaborate {};
         example-max =
           # Spec.hs isn't checked into the repo

--- a/default.nix
+++ b/default.nix
@@ -43,6 +43,15 @@ let
   # function to bring devtools in to a package environment
   devtools = old: { nativeBuildInputs = old.nativeBuildInputs ++ [ nixpkgs.cabal-install nixpkgs.ghcid ]; }; # ghc and hpack are automatically included
   # use overridden-haskellPackages to call source
-  drv = haskellPackages.callCabal2nix "collaborate" ./examples/collaborate {};
+  executables = with nixpkgs.haskell.lib; [
+    (haskellPackages.callCabal2nix "kyowon-server" ./kyowon-server {})
+    (haskellPackages.callCabal2nix "collaborate" ./examples/collaborate {})
+    (
+      dontCheck # Spec.hs isn't checked into the repo
+        (haskellPackages.callCabal2nix "max" ./examples/max {})
+    )
+    #(haskellPackages.callCabal2nix "event" ./examples/event {}) # has a bug in the cabalfile
+  ];
+  drv = nixpkgs.buildEnv { name = "vrdt-project"; paths = executables; };
 in
-if nixpkgs.lib.inNixShell then (drv.envFunc { hoogle = true; }).overrideAttrs devtools else drv
+if nixpkgs.lib.inNixShell then (nixpkgs.lib.head executables).env.overrideAttrs devtools else drv


### PR DESCRIPTION
there seem to be some things broken in the current version

* kyowon-reflex
    * the tests are missing language-extensions
    * a commented application operator is a haddock parse error
* vrdt
    * Spec.hs isn't checked into the repo
    * commented guard case is a haddock parse error 

therefore the nix file disables haddock and tests in those two packages